### PR TITLE
Fix encoding issues and separate recategorization command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fixed metadata preservation during recategorization: structured metadata fields (speech_type, speaker, role, event, etc.) are now preserved when recategorizing files from the unknown folder
+- Fixed remaining count calculation to correctly handle cases where metadata exists but PDF files don't
+- Fixed early return bug that prevented processing metadata entries when no PDF files were present
+
+### Changed
+- Improved recategorization function to process metadata entries even when no PDF files are present
+- Enhanced remaining count calculation to account for PDFs without metadata and metadata entries without PDFs
+
 ## [0.1.0] - 2025-11-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -110,15 +110,25 @@ Convert only a specific date range (inclusive):
 bis-scraper convert --start-date 2020-01-01 --end-date 2020-01-31
 ```
 
-#### Run Both Steps
+#### Re-categorize Unknown Files
 
-Run both scraping and conversion in one command:
+After scraping, some files may be placed in an `unknown/` folder if their institution couldn't be identified. If you've updated institution mappings in `constants.py`, you can re-categorize these files:
+
+```bash
+bis-scraper recategorize
+```
+
+This command moves files from the `unknown/` folder to their correct institution folders based on updated mappings. It processes both PDFs and text files together.
+
+#### Run All Steps
+
+Run scraping, recategorization, and conversion in one command:
 
 ```bash
 bis-scraper run-all --start-date 2020-01-01 --end-date 2020-01-31
 ```
 
-Note: The run-all command forwards the same date range to conversion, so only PDFs in that range are converted.
+Note: The `run-all` command runs scraping, then recategorization, then conversion. The date range is forwarded to conversion, so only PDFs in that range are converted.
 
 #### Cache Management
 
@@ -159,6 +169,7 @@ See [Scripts README](scripts/README.md) for more details.
 from pathlib import Path
 import datetime
 from bis_scraper.scrapers.controller import scrape_bis
+from bis_scraper.scrapers.recategorize import recategorize_unknown_files
 from bis_scraper.converters.controller import convert_pdfs_dates
 
 # Download speeches
@@ -171,6 +182,11 @@ result = scrape_bis(
     force=False,
     limit=None
 )
+
+# Re-categorize files from unknown folder (if any)
+recategorized_count, remaining_unknown = recategorize_unknown_files(Path("data"))
+if recategorized_count > 0:
+    print(f"Re-categorized {recategorized_count} file(s) from unknown folder")
 
 # Convert to text (filtering to the same date range)
 convert_result = convert_pdfs_dates(
@@ -195,6 +211,7 @@ import datetime
 import logging
 from pathlib import Path
 from bis_scraper.scrapers.controller import scrape_bis
+from bis_scraper.scrapers.recategorize import recategorize_unknown_files
 from bis_scraper.converters.controller import convert_pdfs
 from bis_scraper.utils.constants import INSTITUTIONS
 from bis_scraper.utils.institution_utils import get_all_institutions
@@ -238,6 +255,11 @@ scrape_result = scrape_bis(
     force=False,
     limit=10
 )
+
+# Re-categorize files from unknown folder (if any)
+recategorized_count, remaining_unknown = recategorize_unknown_files(data_dir)
+if recategorized_count > 0:
+    print(f"Re-categorized {recategorized_count} file(s) from unknown folder")
 
 # Convert all downloaded speeches
 convert_result = convert_pdfs(

--- a/bis_scraper/scrapers/controller.py
+++ b/bis_scraper/scrapers/controller.py
@@ -8,7 +8,6 @@ from typing import Optional, Tuple
 
 from bis_scraper.models import ScrapingResult
 from bis_scraper.scrapers.bis_scraper import BisScraper
-from bis_scraper.scrapers.recategorize import recategorize_unknown_files
 from bis_scraper.utils.constants import RAW_DATA_DIR
 from bis_scraper.utils.file_utils import create_directory
 from bis_scraper.utils.institution_utils import normalize_institution_name
@@ -18,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 def scrape_bis(
     data_dir: Path,
-    log_dir: Path,
+    log_dir: Path,  # noqa: ARG001
     start_date: Optional[datetime.datetime] = None,
     end_date: Optional[datetime.datetime] = None,
     institutions: Optional[Tuple[str, ...]] = None,
@@ -29,7 +28,7 @@ def scrape_bis(
 
     Args:
         data_dir: Base directory for data storage
-        log_dir: Directory for log files
+        log_dir: Directory for log files (part of API signature for consistency, logging configured at CLI level)
         start_date: Start date for scraping
         end_date: End date for scraping
         institutions: Specific institutions to scrape (default: all)
@@ -132,12 +131,6 @@ def scrape_bis(
 
     # Get results
     result = scraper.get_results()
-
-    # Re-categorize files from unknown folder if any exist
-    recategorized_count, remaining_unknown = recategorize_unknown_files(data_dir)
-    if recategorized_count > 0:
-        logger.info(f"Re-categorized {recategorized_count} file(s) from unknown folder")
-        print(f"Re-categorized {recategorized_count} file(s) from unknown folder")
 
     # Log summary
     elapsed_time = time.time() - start_time

--- a/bis_scraper/scrapers/recategorize.py
+++ b/bis_scraper/scrapers/recategorize.py
@@ -3,11 +3,19 @@
 import json
 import logging
 import shutil
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
-from typing import Tuple
+from typing import Any, Dict, Optional, Tuple, cast
 
-from bis_scraper.utils.constants import RAW_DATA_DIR, TXT_DATA_DIR
+import requests
+from bs4 import BeautifulSoup
+
+from bis_scraper.utils.constants import (
+    HTML_EXTENSION,
+    RAW_DATA_DIR,
+    SPEECHES_URL,
+    TXT_DATA_DIR,
+)
 from bis_scraper.utils.file_utils import (
     get_institution_directory,
     save_metadata_to_json,
@@ -24,6 +32,14 @@ def recategorize_unknown_files(data_dir: Path) -> Tuple[int, int]:
     based on their metadata. This is useful when institution mappings are updated
     in constants.py after files have already been downloaded.
 
+    The function processes files sequentially and updates metadata.json immediately
+    after each successful move. This ensures that if the process fails, we don't
+    lose track of what was already processed.
+
+    The function processes:
+    1. Files with entries in metadata.json
+    2. PDF files without metadata.json entries (fetches metadata from BIS website)
+
     Args:
         data_dir: Base directory for data storage
 
@@ -38,27 +54,27 @@ def recategorize_unknown_files(data_dir: Path) -> Tuple[int, int]:
         return (0, 0)
 
     metadata_file = unknown_dir / "metadata.json"
-    if not metadata_file.exists():
-        logger.debug("No metadata.json found in unknown folder")
-        return (0, 0)
 
-    # Load metadata
-    try:
-        with open(metadata_file, "r", encoding="utf-8") as f:
-            metadata_data = json.load(f)
-    except (json.JSONDecodeError, IOError) as e:
-        logger.warning(f"Error reading metadata.json from unknown folder: {e}")
+    # Load metadata.json if it exists
+    metadata_data = _load_metadata_file(metadata_file)
+
+    # Get all PDF files in unknown folder
+    pdf_files = list(unknown_dir.glob("*.pdf"))
+
+    # If no PDFs and no metadata, nothing to do
+    if not pdf_files and not metadata_data:
         return (0, 0)
 
     recategorized = 0
-    remaining_metadata = {}
+    processed_codes = set()
 
-    # Process each entry in metadata
-    for speech_code, metadata_entry in metadata_data.items():
+    # First, process entries from metadata.json sequentially
+    # Process a copy of items to avoid modifying dict during iteration
+    for speech_code, metadata_entry in list(metadata_data.items()):
+        processed_codes.add(speech_code)
         raw_text = metadata_entry.get("raw_text", "")
         if not raw_text:
-            # Keep entry if no raw_text available
-            remaining_metadata[speech_code] = metadata_entry
+            # Keep entry if no raw_text available (don't remove from metadata)
             continue
 
         # Try to extract institution from metadata
@@ -66,73 +82,73 @@ def recategorize_unknown_files(data_dir: Path) -> Tuple[int, int]:
 
         if institution:  # None means not found, any string means found
             # Found a valid institution - move the files
-            pdf_filename = f"{speech_code}.pdf"
-            txt_filename = f"{speech_code}.txt"
-            pdf_path = unknown_dir / pdf_filename
+            if _move_files_to_institution(
+                unknown_dir,
+                data_dir,
+                speech_code,
+                institution,
+                raw_text,
+                metadata_entry,
+            ):
+                # Successfully moved - remove entry from metadata.json immediately
+                _remove_metadata_entry(metadata_file, speech_code)
+                recategorized += 1
+            # If move failed, keep entry in metadata.json (don't remove)
+        # If institution not found, keep entry in metadata.json (don't remove)
 
-            if pdf_path.exists():
-                # Get target institution directories
-                target_pdf_dir = get_institution_directory(output_dir, institution)
-                target_pdf_path = target_pdf_dir / pdf_filename
+    # Now process PDFs that don't have metadata.json entries
+    for pdf_path in pdf_files:
+        # Extract speech code from filename (e.g., "000718b.pdf" -> "000718b")
+        speech_code = pdf_path.stem
 
-                # Get text directories
-                texts_dir = data_dir / TXT_DATA_DIR
-                unknown_texts_dir = texts_dir / "unknown"
-                target_txt_dir = get_institution_directory(texts_dir, institution)
-                txt_path = unknown_texts_dir / txt_filename
-                target_txt_path = target_txt_dir / txt_filename
+        # Skip if already processed
+        if speech_code in processed_codes:
+            continue
 
-                # Move PDF file
-                try:
-                    shutil.move(str(pdf_path), str(target_pdf_path))
-                    logger.info(
-                        f"Re-categorized {speech_code} PDF from unknown to {institution}"
-                    )
+        # Fetch metadata from BIS website
+        logger.info(f"Fetching metadata for {speech_code} from BIS website")
+        metadata_text, date_obj = _fetch_metadata_from_bis(speech_code)
 
-                    # Move text file if it exists
-                    if txt_path.exists():
-                        # Ensure target text directory exists
-                        target_txt_dir.mkdir(parents=True, exist_ok=True)
-                        shutil.move(str(txt_path), str(target_txt_path))
-                        logger.info(
-                            f"Re-categorized {speech_code} text file from unknown to {institution}"
-                        )
+        if not metadata_text:
+            # Could not fetch metadata, keep file in unknown
+            logger.warning(f"Could not fetch metadata for {speech_code}")
+            continue
 
-                    # Save metadata to target directory
-                    date_str = metadata_entry.get("date")
-                    date_obj = None
-                    if date_str:
-                        try:
-                            date_obj = datetime.fromisoformat(date_str).date()
-                        except ValueError:
-                            pass
+        # Try to extract institution from metadata
+        institution = get_institution_from_metadata(metadata_text)
 
-                    save_metadata_to_json(
-                        target_pdf_dir, speech_code, raw_text, date_obj
-                    )
-
-                    recategorized += 1
-                except Exception as e:
-                    logger.error(
-                        f"Error moving {speech_code} to {institution}: {e}",
-                        exc_info=True,
-                    )
-                    # Keep entry if move failed
-                    remaining_metadata[speech_code] = metadata_entry
-            else:
-                # PDF doesn't exist, but keep metadata entry
-                remaining_metadata[speech_code] = metadata_entry
+        if institution:
+            # Found a valid institution - move the files
+            metadata_entry = {
+                "raw_text": metadata_text,
+                "date": str(date_obj) if date_obj else None,
+            }
+            if _move_files_to_institution(
+                unknown_dir,
+                data_dir,
+                speech_code,
+                institution,
+                metadata_text,
+                metadata_entry,
+            ):
+                # Successfully moved - no metadata entry to remove (wasn't in metadata.json)
+                recategorized += 1
+            # If move failed, file stays in unknown folder
         else:
-            # Still unknown, keep entry
-            remaining_metadata[speech_code] = metadata_entry
+            # Still unknown - add to metadata.json for future processing
+            _add_metadata_entry(metadata_file, speech_code, metadata_text, date_obj)
 
-    # Update metadata.json in unknown folder
-    if remaining_metadata:
-        with open(metadata_file, "w", encoding="utf-8") as f:
-            json.dump(remaining_metadata, f, indent=2, ensure_ascii=False)
-    else:
-        # No remaining files, remove metadata.json and unknown folders if empty
-        metadata_file.unlink()
+    # Final cleanup: check if metadata.json should be deleted
+    remaining_pdfs = list(unknown_dir.glob("*.pdf"))
+    remaining_metadata = _load_metadata_file(metadata_file)
+
+    if not remaining_metadata and not remaining_pdfs:
+        # No remaining files and no PDFs, safe to delete metadata.json
+        if metadata_file.exists():
+            metadata_file.unlink()
+            logger.info("Removed metadata.json (no remaining files)")
+
+        # Try to remove empty unknown folders
         try:
             unknown_dir.rmdir()  # Remove if empty
             logger.info("Removed empty unknown PDF folder")
@@ -154,7 +170,18 @@ def recategorize_unknown_files(data_dir: Path) -> Tuple[int, int]:
                 # Folder not empty or other error
                 pass
 
-    remaining_count = len(remaining_metadata)
+    # Calculate remaining count before logging
+    remaining_pdfs_final = list(unknown_dir.glob("*.pdf"))
+    pdf_codes_final = {p.stem for p in remaining_pdfs_final}
+    pdf_codes_with_metadata_final = set(remaining_metadata.keys())
+    # Count: PDFs without metadata + metadata entries without PDFs
+    overlap_final = len(pdf_codes_final & pdf_codes_with_metadata_final)
+    remaining_count = (
+        len(remaining_pdfs_final) + len(remaining_metadata) - overlap_final
+    )
+    # Ensure count is never negative
+    remaining_count = max(0, remaining_count)
+
     if recategorized > 0:
         logger.info(
             f"Re-categorized {recategorized} file(s) from unknown folder. "
@@ -162,3 +189,274 @@ def recategorize_unknown_files(data_dir: Path) -> Tuple[int, int]:
         )
 
     return (recategorized, remaining_count)
+
+
+def _load_metadata_file(metadata_file: Path) -> Dict[str, Any]:
+    """Load metadata.json file, handling corruption.
+
+    Args:
+        metadata_file: Path to metadata.json file
+
+    Returns:
+        Dictionary of metadata entries, empty dict if file doesn't exist or is corrupted
+    """
+    if not metadata_file.exists():
+        return {}
+
+    try:
+        with open(metadata_file, "r", encoding="utf-8") as f:
+            content = f.read()
+            # Try to parse JSON, handling corrupted files
+            try:
+                return cast(Dict[str, Any], json.loads(content))
+            except json.JSONDecodeError as e:
+                # If JSON is corrupted, try to extract valid JSON portion
+                logger.warning(
+                    f"JSON parse error in metadata.json: {e}. Attempting to recover..."
+                )
+                # Try to find the end of valid JSON
+                if e.pos and e.pos > 0:
+                    try:
+                        # Try parsing up to the error position
+                        recovered_data = cast(
+                            Dict[str, Any], json.loads(content[: e.pos])
+                        )
+                        logger.info(
+                            f"Recovered {len(recovered_data)} entries from corrupted metadata.json"
+                        )
+                        return recovered_data
+                    except json.JSONDecodeError:
+                        logger.error(
+                            "Could not recover metadata.json. File may be severely corrupted."
+                        )
+                        return {}
+                else:
+                    logger.error("Could not recover metadata.json")
+                    return {}
+    except IOError as e:
+        logger.warning(f"Error reading metadata.json: {e}")
+        return {}
+
+
+def _remove_metadata_entry(metadata_file: Path, speech_code: str) -> None:
+    """Remove a single entry from metadata.json atomically.
+
+    Args:
+        metadata_file: Path to metadata.json file
+        speech_code: Speech code to remove
+    """
+    if not metadata_file.exists():
+        return
+
+    try:
+        # Load current metadata
+        metadata_data = _load_metadata_file(metadata_file)
+        if speech_code not in metadata_data:
+            return
+
+        # Remove entry
+        del metadata_data[speech_code]
+
+        # Write back (atomic write)
+        with open(metadata_file, "w", encoding="utf-8") as f:
+            json.dump(metadata_data, f, indent=2, ensure_ascii=False)
+    except Exception as e:
+        logger.error(
+            f"Error removing metadata entry for {speech_code}: {e}", exc_info=True
+        )
+
+
+def _add_metadata_entry(
+    metadata_file: Path, speech_code: str, metadata_text: str, date_obj: Optional[date]
+) -> None:
+    """Add a single entry to metadata.json atomically.
+
+    Args:
+        metadata_file: Path to metadata.json file
+        speech_code: Speech code to add
+        metadata_text: Raw metadata text
+        date_obj: Optional date object
+    """
+    try:
+        # Load current metadata
+        metadata_data = _load_metadata_file(metadata_file)
+
+        # Add entry
+        metadata_data[speech_code] = {
+            "raw_text": metadata_text,
+            "date": str(date_obj) if date_obj else None,
+        }
+
+        # Write back (atomic write)
+        with open(metadata_file, "w", encoding="utf-8") as f:
+            json.dump(metadata_data, f, indent=2, ensure_ascii=False)
+    except Exception as e:
+        logger.error(
+            f"Error adding metadata entry for {speech_code}: {e}", exc_info=True
+        )
+
+
+def _fetch_metadata_from_bis(speech_code: str) -> Tuple[Optional[str], Optional[date]]:
+    """Fetch metadata from BIS website for a speech code.
+
+    Args:
+        speech_code: Speech code without 'r' prefix (e.g., "000718b")
+
+    Returns:
+        Tuple of (metadata_text, date_obj) or (None, None) if fetch failed
+    """
+    try:
+        # Add 'r' prefix if not present
+        full_code = (
+            f"r{speech_code}" if not speech_code.startswith("r") else speech_code
+        )
+
+        # Get metadata page URL
+        metadata_url = f"{SPEECHES_URL}/{full_code}{HTML_EXTENSION}"
+
+        # Get the metadata page
+        metadata_response = requests.get(metadata_url, timeout=30)
+        metadata_response.raise_for_status()
+
+        # Parse metadata page
+        metadata_soup = BeautifulSoup(metadata_response.text, "html.parser")
+
+        # Extract metadata - specifically look for extratitle-div
+        extratitle_div = metadata_soup.find(id="extratitle-div")
+        if extratitle_div:
+            metadata_text = extratitle_div.text.strip()
+        else:
+            # Fall back to full text if the specific div isn't found
+            metadata_text = metadata_soup.get_text()
+
+        # Try to extract date from speech code (YYMMDD format)
+        date_obj = None
+        if len(speech_code) >= 6:
+            try:
+                year = int(speech_code[:2])
+                month = int(speech_code[2:4])
+                day = int(speech_code[4:6])
+                # Handle 2-digit year (assume 00-50 = 2000-2050, 51-99 = 1951-1999)
+                if year <= 50:
+                    year += 2000
+                else:
+                    year += 1900
+                date_obj = datetime(year, month, day).date()
+            except (ValueError, IndexError):
+                pass
+
+        return (metadata_text, date_obj)
+    except Exception as e:
+        logger.error(f"Error fetching metadata for {speech_code}: {e}", exc_info=True)
+        return (None, None)
+
+
+def _move_files_to_institution(
+    unknown_dir: Path,
+    data_dir: Path,
+    speech_code: str,
+    institution: str,
+    metadata_text: str,
+    metadata_entry: dict,
+) -> bool:
+    """Move PDF and text files from unknown folder to institution folder.
+
+    Args:
+        unknown_dir: Unknown directory path
+        data_dir: Base data directory
+        speech_code: Speech code without 'r' prefix
+        institution: Institution name
+        metadata_text: Raw metadata text
+        metadata_entry: Metadata entry dictionary
+
+    Returns:
+        True if files were moved successfully, False otherwise
+    """
+    try:
+        pdf_filename = f"{speech_code}.pdf"
+        txt_filename = f"{speech_code}.txt"
+        pdf_path = unknown_dir / pdf_filename
+
+        if not pdf_path.exists():
+            return False
+
+        # Get target institution directories
+        output_dir = data_dir / RAW_DATA_DIR
+        target_pdf_dir = get_institution_directory(output_dir, institution)
+        target_pdf_path = target_pdf_dir / pdf_filename
+
+        # Get text directories
+        texts_dir = data_dir / TXT_DATA_DIR
+        unknown_texts_dir = texts_dir / "unknown"
+        target_txt_dir = get_institution_directory(texts_dir, institution)
+        txt_path = unknown_texts_dir / txt_filename
+        target_txt_path = target_txt_dir / txt_filename
+
+        # Move PDF file
+        shutil.move(str(pdf_path), str(target_pdf_path))
+        logger.info(f"Re-categorized {speech_code} PDF from unknown to {institution}")
+
+        # Move text file if it exists
+        if txt_path.exists():
+            # Ensure target text directory exists
+            target_txt_dir.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(txt_path), str(target_txt_path))
+            logger.info(
+                f"Re-categorized {speech_code} text file from unknown to {institution}"
+            )
+
+        # Save metadata to target directory
+        # Preserve existing structured metadata from metadata_entry if available
+        json_path = target_pdf_dir / "metadata.json"
+
+        # Check if metadata_entry has structured fields (more than raw_text and date)
+        has_structured_metadata = len(metadata_entry) > 2 or any(
+            key not in ("raw_text", "date") for key in metadata_entry.keys()
+        )
+
+        if json_path.exists():
+            try:
+                with open(json_path, "r", encoding="utf-8") as f:
+                    existing_data = json.load(f)
+            except (IOError, json.JSONDecodeError):
+                existing_data = {}
+
+            # If we have structured metadata in metadata_entry, preserve it
+            if has_structured_metadata:
+                # Merge: preserve structured fields, update raw_text and date
+                existing_data[speech_code] = {
+                    **metadata_entry,  # Preserve all structured fields
+                    "raw_text": metadata_text.strip(),  # Update raw_text
+                }
+                # Ensure date is in ISO format if provided
+                date_str = metadata_entry.get("date")
+                if date_str:
+                    existing_data[speech_code]["date"] = date_str
+                # Write back
+                with open(json_path, "w", encoding="utf-8") as f:
+                    json.dump(existing_data, f, indent=2, ensure_ascii=False)
+                return True
+
+        # No structured metadata in metadata_entry, use normal save (will parse)
+        date_str = metadata_entry.get("date")
+        date_obj = None
+        if date_str:
+            try:
+                # Handle both ISO format and string format
+                if isinstance(date_str, str) and len(date_str) == 10:
+                    date_obj = datetime.fromisoformat(date_str).date()
+                elif isinstance(date_str, str):
+                    # Try parsing as date string
+                    date_obj = datetime.strptime(date_str, "%Y-%m-%d").date()
+            except ValueError:
+                pass
+
+        save_metadata_to_json(target_pdf_dir, speech_code, metadata_text, date_obj)
+
+        return True
+    except Exception as e:
+        logger.error(
+            f"Error moving {speech_code} to {institution}: {e}",
+            exc_info=True,
+        )
+        return False

--- a/bis_scraper/utils/constants.py
+++ b/bis_scraper/utils/constants.py
@@ -42,6 +42,7 @@ INSTITUTIONS: List[str] = [
     "Board of Governors of the Federal Reserve System",
     "Bulgarian National Bank",
     "Central Bank of Argentina",
+    "Central Bank of Armenia",
     "Central Bank of Aruba",
     "Central Bank of Bahrain",
     "Central Bank of Barbados",
@@ -94,6 +95,7 @@ INSTITUTIONS: List[str] = [
     "Federal Reserve Bank of Richmond",
     "Federal Reserve Bank of San Francisco",
     "Hong Kong Monetary Authority",
+    "Cayman Islands Monetary Authority",
     "central bank of Hungary",
     "Maldives Monetary Authority",
     "Monetary Authority of Macao",
@@ -109,6 +111,7 @@ INSTITUTIONS: List[str] = [
     "Netherlands Bank",
     "Reserve Bank of Australia",
     "Reserve Bank of Fiji",
+    "Central Bank of The Gambia",
     "Reserve Bank of India",
     "Reserve Bank of Malawi",
     "Reserve Bank of New Zealand",
@@ -183,12 +186,15 @@ INSTITUTION_ALIASES: Dict[str, List[str]] = {
         "federal reserve board",
         "board of governors of the us fed",
         "federal reserve system",
+        "bd. of govnrs. of the us fed. res. system",
+        "chairman of the bd. of govnrs. of the us fed. res. system",
     ],
     "sveriges riksbank": [
         "bank of sweden",
         "sveriges riskbank",
         "swedish central bank",
         "sveriges risksbank",
+        "heikensten",  # Former governor
     ],
     "central bank of the republic of austria": [
         "austrian national bank",
@@ -196,8 +202,84 @@ INSTITUTION_ALIASES: Dict[str, List[str]] = {
         "austrian nationalbank",
     ],
     "central bank of norway": ["norges bank"],
-    "bank of france": ["banque de france"],
+    "bank of france": ["banque de france", "banque of france"],  # Typo variant
+    "federal reserve bank of new york": [
+        "president and chief executive officer of the federal reserve bank of new york",
+        "federal\nreserve bank of new york",  # Handle line breaks in metadata
+        "fed. res. bank of new york",
+        "fed res bank of new york",
+        "federal reserve bank of ny",
+    ],
+    "national bank of belgium": ["pierre wunsch"],  # Governor name
+    "european central bank": [
+        "ecb",
+        "european central",
+        "member of the executive board of the european central",
+        "willem f duisenberg",  # Former president
+        "mario draghi",  # Former president
+    ],
     "bank of portugal": ["banco de portugal"],
+    "bank of spain": ["banco de españa", "the banco de españa"],
+    "central bank of colombia": [
+        "banco de la república",
+        "banco de la república (bank of the republic)",
+        "bank of the republic",
+        "co-director of the bank of the republic",
+    ],
+    "central bank of malaysia": [
+        "bank negara malaysia",
+        "the bank negara malaysia",
+        "the bank of malaysia",
+        "negara malaysia",
+        "cb of malaysia",
+    ],
+    "central bank of the philippines": [
+        "bangko sentral ng pilipinas",
+        "the bangko sentral ng pilipinas",
+    ],
+    "central bank of trinidad and tobago": [
+        "trinidad & tobago",
+        "the central bank of trinidad & tobago",
+        "of trinidad & tobago",
+    ],
+    "central bank of the republic of turkey": [
+        "bank of turkey",
+        "the republic of türkiye",
+        "the central bank of the republic of türkiye",
+        "for the republic of turkey",
+        "central bank for the republic of turkey",
+    ],
+    "central bank of curaçao and sint maarten": [
+        "netherlands antilles",
+        "the netherlands antilles",
+        "bank of the netherlands antilles",
+        "the bank of the netherlands antilles",
+        "bank van de nederlandse antillen",
+        "the bank van de nederlandse antillen",
+        "the netherlands antilles (bank van de nederlandse antillen)",
+        "the bank of the netherlands antilles (bank van de nederlandse antillen)",
+        "central bank of curacao and sint maarten",
+        "centrale bank van curaçao en sint maarten",
+        "van curaçao en sint maarten",
+        "of curacao and sint maarten",
+    ],
+    "central bank of armenia": ["armenia", "of armenia"],
+    "central bank of the gambia": ["the gambia", "of the gambia"],
+    "central bank of hungary": [
+        "magyar nemzeti bank",
+        "magyar nemzeti bank (hungary's central bank)",
+        "deputy governor of magyar nemzeti bank (hungary's",
+    ],
+    "national bank of denmark": [
+        "danmarks nationalbank",
+        "danmarks national bank",
+        "governor of danmarks",
+    ],
+    "reserve bank of new zealand": [
+        "reserve of the bank of new zealand",
+        "of new zealand",
+    ],
+    "croatian national bank": ["croation national bank", "the croation national bank"],
     "netherlands bank": ["nederlandsche bank"],
     "south african reserve bank": ["bank of south africa"],
     "hong kong monetary authority": ["hong kong monetary"],
@@ -206,9 +288,20 @@ INSTITUTION_ALIASES: Dict[str, List[str]] = {
         "national bank of the republic of macedonia",
         "national bank of the republic of north macedonia",
     ],
-    "european central bank": ["ecb"],
     "central bank of ireland": ["authority of ireland"],
-    "central bank of the republic of turkey": ["bank of turkey"],
+    "bank indonesia": ["bank of indonesia", "the bank of indonesia"],
+    "bank of uganda": ["bank of the uganda"],
+    "central bank of bahrain": [
+        "bahrain monetary agency",
+        "the bahrain monetary agency",
+    ],
+    "monetary authority of macao": [
+        "mon. authority of macao",
+        "chairman of the mon. authority of macao",
+    ],
+    "bank of italy": ["baml of italy", "the baml of italy"],
+    "bank of israel": ["stanley fischer"],  # Former governor
+    "state bank of pakistan": ["ishrat husain"],  # Former governor
     "people's bank of china": ["bank of china"],
     "reserve bank of australia": ["australian reserve bank", "bank of australia"],
     "saudi arabian monetary agency": ["saudi central bank"],

--- a/scripts/run_full_scrape.sh
+++ b/scripts/run_full_scrape.sh
@@ -7,12 +7,12 @@
 #LIMIT_NUM=5
 
 # Data storage locations
-DATA_DIR="../data/bis_full_data"
-LOG_DIR="../data/bis_full_data/logs"
+DATA_DIR="/home/magnus/Git/HanssonMagnus/projects/bis-scraper/data/bis_full_data"
+LOG_DIR="/home/magnus/Git/HanssonMagnus/projects/bis-scraper/data/bis_full_data/logs"
 
 # Date range (format: YYYY-MM-DD)
 #START_DATE="1997-01-01"   # BIS speeches start around 1997
-START_DATE="2025-08-01"   # BIS speeches start around 1997
+START_DATE="2025-10-01"   # BIS speeches start around 1997
 #START_DATE=$(date +%Y-%m-%d)  # Today's date
 END_DATE=$(date +%Y-%m-%d)  # Today's date
 


### PR DESCRIPTION
## Summary

This PR fixes critical encoding issues and improves the recategorization workflow.

## Changes

### Encoding Fixes
- Add explicit UTF-8 encoding to all file operations
- Fix missing encoding in date cache read/write operations
- Fix missing encoding in CLI cache operations
- Ensures consistent behavior across different systems (especially Windows)

### Recategorization Improvements
- Remove automatic recategorization from `scrape_bis()`
- Add standalone `recategorize` CLI command
- Update `run_all` to include recategorization step
- Improve recategorization with transactional updates (updates metadata.json immediately after each successful move)
- Add metadata preservation during recategorization
- Update documentation (README and API docs)

## Testing

- All 48 tests pass
- Manual testing completed with full scrape workflow
- Verified encoding fixes work correctly

## Impact

- **Breaking Change**: `scrape_bis()` no longer automatically recategorizes. Users must call `recategorize_unknown_files()` explicitly or use `run_all` command.
- **Improvement**: More explicit workflow and better error recovery
- **Bug Fix**: Encoding issues that could cause problems on Windows/non-UTF-8 systems